### PR TITLE
update to display-interface branch ehal1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.61"
 
 [dependencies]
-display-interface = { git = "https://github.com/bugadani/display-interface.git", branch = "ehal1"}
+display-interface = { git = "https://github.com/therealprof/display-interface", version = "0.5.0-alpha.1" }
 embedded-graphics-core = "0.4.0"
 embedded-hal = "1.0.0-alpha.11"
 embedded-hal-async = "0.2.0-alpha.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mipidsi"
 description = "MIPI Display Serial Interface generic driver"
-version = "0.7.1"
+version = "0.8.0-alpha.1"
 authors = ["Ales Katona <almindor@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -12,10 +12,10 @@ documentation = "https://docs.rs/mipidsi"
 rust-version = "1.61"
 
 [dependencies]
-display-interface = { git = "https://github.com/bugadani/display-interface.git", branch = "async"}
+display-interface = { git = "https://github.com/bugadani/display-interface.git", branch = "ehal1"}
 embedded-graphics-core = "0.4.0"
-embedded-hal = "1.0.0-alpha.10"
-embedded-hal-async = "0.2.0-alpha.1"
+embedded-hal = "1.0.0-alpha.11"
+embedded-hal-async = "0.2.0-alpha.2"
 nb = "1.0.0"
 
 [dependencies.heapless]

--- a/src/models.rs
+++ b/src/models.rs
@@ -10,7 +10,7 @@ use embedded_graphics_core::prelude::RgbColor;
 use embedded_hal::{delay::DelayUs, digital::OutputPin};
 
 // existing model implementations
-// mod gc9a01;
+mod gc9a01;
 // mod ili9341;
 // mod ili9342c;
 // mod ili934x;
@@ -18,7 +18,7 @@ use embedded_hal::{delay::DelayUs, digital::OutputPin};
 // mod st7735s;
 mod st7789;
 
-// pub use gc9a01::*;
+pub use gc9a01::*;
 // pub use ili9341::*;
 // pub use ili9342c::*;
 // pub use ili9486::*;

--- a/src/models/gc9a01.rs
+++ b/src/models/gc9a01.rs
@@ -147,6 +147,16 @@ impl Model for GC9A01 {
         dcs.di.send_data(buf)?;
         Ok(())
     }
+
+    fn write_pixels_raw<DI>(&mut self, dcs: &mut Dcs<DI>, colors: &mut [u16]) -> Result<(), Error>
+    where
+        DI: WriteOnlyDataCommand,
+    {
+        dcs.write_command(WriteMemoryStart)?;
+        let buf = DataFormat::U16BE(colors);
+        dcs.di.send_data(buf)?;
+        Ok(())
+    }
 }
 
 // simplified constructor on Display


### PR DESCRIPTION
I know this fork is a proof of concept but since the main dependancy display-interface has evolved to use newer embedded-hal and embedded-hal-async (in its new branch ehal1), the update could be done here too.

And by the way, I upgraded and enabled gc9a01 model to this new proof of concept as I needed it.